### PR TITLE
Updated 30sftp.ex and added hashsum parameter

### DIFF
--- a/doc/30sftp.ex
+++ b/doc/30sftp.ex
@@ -1,8 +1,8 @@
 Acquire {
   sftp {
-    timeout::myhost:2222=40;
-    Username::myhost:2222=repo;
-    PrivkeyFile::myhost:2222=/var/srepo/sftp;
-    PubkeyFile::myhost:2222=/var/srepo/sftp.pub;
+    timeout 40;
+    Username repo;
+    PrivkeyFile /var/srepo/sftp;
+    PubkeyFile /var/srepo/sftp.pub;
   };
 };


### PR DESCRIPTION
This package has been very usefull to me, had to make two small changes however, for it to work:

1. Probably a more recent change to apt added hashes to repository, so this was resulting in a "hash sum mismatch" error. Fixed it similarly to how it is done in ftp or https transport for example.

2. Also, syntax of configuration file has slightly changed, so updated 30sftp.ex in doc accordingly.
